### PR TITLE
Second PR for code edited during competition (click for summary)

### DIFF
--- a/src/main/java/com/spartronics4915/frc2022/Constants.java
+++ b/src/main/java/com/spartronics4915/frc2022/Constants.java
@@ -66,6 +66,7 @@ public final class Constants
         public static final double kEjectSpeed = -0.6;
         
         public static final double kRetractIntakeDelay = 0.3;
+        public static final double kIntakeMotorDelay = .5;
 
         public static final int kMaxCurrent = 30;
     }

--- a/src/main/java/com/spartronics4915/frc2022/Constants.java
+++ b/src/main/java/com/spartronics4915/frc2022/Constants.java
@@ -66,7 +66,7 @@ public final class Constants
         public static final double kEjectSpeed = -0.6;
         
         public static final double kRetractIntakeDelay = 0.3;
-        public static final double kIntakeMotorDelay = .5;
+        public static final double kIntakeStopMotorDelay = 1;
 
         public static final int kMaxCurrent = 30;
     }

--- a/src/main/java/com/spartronics4915/frc2022/Constants.java
+++ b/src/main/java/com/spartronics4915/frc2022/Constants.java
@@ -148,7 +148,7 @@ public final class Constants
         /**
          * Climber will be put down before every match so that's where 0 is.
          */
-        public static final double kMinRotations = 0;
+        public static final double kMinRotations = -200000;
 
         /**
          * Takes 12 rotations of climber to rotate winch.

--- a/src/main/java/com/spartronics4915/frc2022/Constants.java
+++ b/src/main/java/com/spartronics4915/frc2022/Constants.java
@@ -184,6 +184,7 @@ public final class Constants
         public static final int kConveyorReverseBothButton = 3;
         public static final int kConveyorReverseBottomButton = 4;
         public static final int kConveyorReverseTopButton = 5;
+        public static final int kConveyorRunBothButton = 1;
 
         public static final int kLauncherShootButton = 6;
         public static final int kLauncherToggleButton = 8;

--- a/src/main/java/com/spartronics4915/frc2022/Constants.java
+++ b/src/main/java/com/spartronics4915/frc2022/Constants.java
@@ -153,7 +153,7 @@ public final class Constants
         /**
          * Takes 12 rotations of climber to rotate winch.
          */
-        public static final double kClimberGearRatio = 12.0;
+        public static final double kClimberGearRatio = 36.0;
         /**
          * For Climber encoder -- divide getIntegratedSensorPosition() by this.
          */

--- a/src/main/java/com/spartronics4915/frc2022/Constants.java
+++ b/src/main/java/com/spartronics4915/frc2022/Constants.java
@@ -164,7 +164,8 @@ public final class Constants
          */
         public static final double kDelay = 0.1; // adjust 1st number for ms
 
-        public static final int kMaxCurrent = 40;
+        //set very high to see if it remembered it was at 40??
+        public static final int kMaxCurrent = 100;
     }
 
     public static final class OIConstants {

--- a/src/main/java/com/spartronics4915/frc2022/RobotContainer.java
+++ b/src/main/java/com/spartronics4915/frc2022/RobotContainer.java
@@ -119,6 +119,7 @@ public class RobotContainer
         return new SequentialCommandGroup(
             mLauncherCommands.new TurnOnLauncher(),
             new WaitCommand(Constants.Autonomous.kShootDelay),
+            new WaitCommand(7),
             mConveyorCommands.new ShootFromTop(),
             mAutonomousCommands.new AutonomousDrive()
         );

--- a/src/main/java/com/spartronics4915/frc2022/RobotContainer.java
+++ b/src/main/java/com/spartronics4915/frc2022/RobotContainer.java
@@ -88,6 +88,8 @@ public class RobotContainer
             .whileHeld(mConveyorCommands.new ReverseBoth());
         new JoystickButton(mArcadeController, OIConstants.kConveyorReverseBottomButton)
             .whileHeld(mConveyorCommands.new ReverseBottom());
+        new JoystickButton(mArcadeController, OIConstants.kConveyorRunBothButton)
+            .whileHeld(mConveyorCommands.new RunBoth());
             
         new JoystickButton(mArcadeController, OIConstants.kLauncherShootButton)
             .whenPressed(new SequentialCommandGroup(

--- a/src/main/java/com/spartronics4915/frc2022/RobotContainer.java
+++ b/src/main/java/com/spartronics4915/frc2022/RobotContainer.java
@@ -119,7 +119,6 @@ public class RobotContainer
         return new SequentialCommandGroup(
             mLauncherCommands.new TurnOnLauncher(),
             new WaitCommand(Constants.Autonomous.kShootDelay),
-            new WaitCommand(7),
             mConveyorCommands.new ShootFromTop(),
             mAutonomousCommands.new AutonomousDrive()
         );

--- a/src/main/java/com/spartronics4915/frc2022/commands/ConveyorCommands.java
+++ b/src/main/java/com/spartronics4915/frc2022/commands/ConveyorCommands.java
@@ -65,9 +65,9 @@ public class ConveyorCommands {
 
         @Override
         public void end(boolean interrupted) {
-            mConveyor.setState(State.FILL);
+            mConveyor.setState(State.OFF);
             if(!mIntake.getToggleState())
-                mIntake.startIntake(false);
+                mIntake.stopIntake();
         }
     }
 

--- a/src/main/java/com/spartronics4915/frc2022/commands/ConveyorCommands.java
+++ b/src/main/java/com/spartronics4915/frc2022/commands/ConveyorCommands.java
@@ -65,8 +65,9 @@ public class ConveyorCommands {
 
         @Override
         public void end(boolean interrupted) {
-            mConveyor.setState(State.OFF);
-            mIntake.startIntake(false);
+            mConveyor.setState(State.FILL);
+            if(!mIntake.getToggleState())
+                mIntake.startIntake(false);
         }
     }
 

--- a/src/main/java/com/spartronics4915/frc2022/commands/ConveyorCommands.java
+++ b/src/main/java/com/spartronics4915/frc2022/commands/ConveyorCommands.java
@@ -53,6 +53,23 @@ public class ConveyorCommands {
         }
     }
 
+    public class RunBoth extends CommandBase{
+        public RunBoth() {
+            addRequirements(mConveyor);
+        }
+
+        @Override
+        public void initialize() {
+            mConveyor.setState(State.RUN_BOTH);
+        }
+
+        @Override
+        public void end(boolean interrupted) {
+            mConveyor.setState(State.OFF);
+            mIntake.startIntake(false);
+        }
+    }
+
     public class ReverseBoth extends CommandBase {
         public ReverseBoth() {
             addRequirements(mConveyor, mIntake);

--- a/src/main/java/com/spartronics4915/frc2022/commands/ConveyorCommands.java
+++ b/src/main/java/com/spartronics4915/frc2022/commands/ConveyorCommands.java
@@ -66,8 +66,6 @@ public class ConveyorCommands {
         @Override
         public void end(boolean interrupted) {
             mConveyor.setState(State.OFF);
-            if(!mIntake.getToggleState())
-                mIntake.stopIntake();
         }
     }
 

--- a/src/main/java/com/spartronics4915/frc2022/commands/IntakeCommands.java
+++ b/src/main/java/com/spartronics4915/frc2022/commands/IntakeCommands.java
@@ -68,7 +68,7 @@ public class IntakeCommands
         {
             addCommands(
                 new InstantCommand(() -> mIntake.retractArm()),
-                new WaitCommand(kIntakeMotorDelay),
+                new WaitCommand(kIntakeStopMotorDelay),
                 new InstantCommand(() -> mIntake.stopMotorAndToggle())
                 );
             addRequirements(mIntake); // Declares subsystem dependencies

--- a/src/main/java/com/spartronics4915/frc2022/commands/IntakeCommands.java
+++ b/src/main/java/com/spartronics4915/frc2022/commands/IntakeCommands.java
@@ -7,6 +7,7 @@ import com.spartronics4915.frc2022.subsystems.Conveyor;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.ConditionalCommand;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 
@@ -61,12 +62,25 @@ public class IntakeCommands
         }
     }
 
+    public class RetractIntakeDelayedMotor extends SequentialCommandGroup
+    {
+        public RetractIntakeDelayedMotor()
+        {
+            addCommands(
+                new InstantCommand(() -> mIntake.retractArm()),
+                new WaitCommand(kIntakeMotorDelay),
+                new InstantCommand(() -> mIntake.stopMotorAndToggle())
+                );
+            addRequirements(mIntake); // Declares subsystem dependencies
+        }
+    }
+
     public class TryToggleIntake extends ConditionalCommand {
         public TryToggleIntake() {
             super(
                 new SequentialCommandGroup(
                     new WaitCommand(kRetractIntakeDelay),
-                    new ToggleIntake()
+                    new RetractIntakeDelayedMotor()
                 ),
                 new ToggleIntake(),
                 mIntake::getToggleState

--- a/src/main/java/com/spartronics4915/frc2022/commands/LauncherCommands.java
+++ b/src/main/java/com/spartronics4915/frc2022/commands/LauncherCommands.java
@@ -137,6 +137,7 @@ public class LauncherCommands {
             mLauncher.setMotorSpeed(mLauncher.getTargetRPS());
         }
     }
+    
     public class TurnOnLauncher extends CommandBase {
         public TurnOnLauncher() {
             addRequirements(mLauncher);
@@ -146,6 +147,31 @@ public class LauncherCommands {
         @Override
         public void initialize() {
             mLauncher.setMotorSpeed(Flywheel.kRPS);
+            mLauncher.setToggleTrue();
+        }
+
+        // Called every time the scheduler runs while the command is scheduled.
+        @Override
+        public void execute() {
+
+        }
+
+        // Called once the command ends or is interrupted.
+        @Override
+        public boolean isFinished() {
+            return true;
+        }
+    }
+
+    public class SliderLaunchStart extends CommandBase {
+        public SliderLaunchStart() {
+            addRequirements(mLauncher);
+        }
+
+        // Called when the command is initially scheduled.
+        @Override
+        public void initialize() {
+            mLauncher.setMotorSpeed(mLauncher.getSlider());
             mLauncher.setToggleTrue();
         }
 

--- a/src/main/java/com/spartronics4915/frc2022/subsystems/Climber.java
+++ b/src/main/java/com/spartronics4915/frc2022/subsystems/Climber.java
@@ -47,7 +47,8 @@ public class Climber extends SpartronicsSubsystem
         }
         logInitialized(success);
         
-        mClimberMotor.configStatorCurrentLimit(new StatorCurrentLimitConfiguration(true, kMaxCurrent, kMaxCurrent, 0));
+        //disable current limit with first variable
+        mClimberMotor.configStatorCurrentLimit(new StatorCurrentLimitConfiguration(false, kMaxCurrent, kMaxCurrent, 0));
 
         mClimberMotor.setNeutralMode(NeutralMode.Brake);
     }

--- a/src/main/java/com/spartronics4915/frc2022/subsystems/Climber.java
+++ b/src/main/java/com/spartronics4915/frc2022/subsystems/Climber.java
@@ -74,7 +74,7 @@ public class Climber extends SpartronicsSubsystem
     /** This method will be called once per scheduler run. */
     @Override
     public void periodic() {
-        // logInfo("ROTATIONS " + getCurrentRotations());
+        logInfo("ROTATIONS " + getCurrentRotations());
 
         double rotations = getCurrentRotations();
 

--- a/src/main/java/com/spartronics4915/frc2022/subsystems/Climber.java
+++ b/src/main/java/com/spartronics4915/frc2022/subsystems/Climber.java
@@ -47,7 +47,7 @@ public class Climber extends SpartronicsSubsystem
         }
         logInitialized(success);
         
-        // mClimberMotor.configStatorCurrentLimit(new StatorCurrentLimitConfiguration(true, kMaxCurrent, kMaxCurrent, 0));
+        mClimberMotor.configStatorCurrentLimit(new StatorCurrentLimitConfiguration(true, kMaxCurrent, kMaxCurrent, 0));
 
         mClimberMotor.setNeutralMode(NeutralMode.Brake);
     }

--- a/src/main/java/com/spartronics4915/frc2022/subsystems/Conveyor.java
+++ b/src/main/java/com/spartronics4915/frc2022/subsystems/Conveyor.java
@@ -22,7 +22,7 @@ public class Conveyor extends SpartronicsSubsystem {
     private DigitalInput mBottomBeamBreaker;
 
     public enum State {
-        OFF, FILL, REVERSE_BOTH, REVERSE_BOTTOM, SHOOT_FROM_BOTTOM, SHOOT_FROM_TOP
+        OFF, FILL, REVERSE_BOTH, REVERSE_BOTTOM, SHOOT_FROM_BOTTOM, SHOOT_FROM_TOP, RUN_BOTH
     };
 
     private State mState = State.OFF;
@@ -105,6 +105,9 @@ public class Conveyor extends SpartronicsSubsystem {
                 break;
             case SHOOT_FROM_TOP:
                 setMotors(0, 1);
+                break;
+            case RUN_BOTH:
+            setMotors(1, 1);
                 break;
         }
     }

--- a/src/main/java/com/spartronics4915/frc2022/subsystems/Intake.java
+++ b/src/main/java/com/spartronics4915/frc2022/subsystems/Intake.java
@@ -58,6 +58,15 @@ public class Intake extends SpartronicsSubsystem
         //logInfo("intake running"); - not sure if we need this could be too much for driver to pay attention to
     }
 
+    public void retractArm(){
+        mIntakeArm.set(false);
+    }
+
+    public void stopMotorAndToggle() {
+        mIntakeMotor.set(0);
+        mToggleState = false;
+    }
+
     public void stopIntake() {
         mIntakeArm.set(false);
         mIntakeMotor.set(0);

--- a/src/main/java/com/spartronics4915/frc2022/subsystems/Launcher.java
+++ b/src/main/java/com/spartronics4915/frc2022/subsystems/Launcher.java
@@ -89,6 +89,10 @@ public class Launcher extends SpartronicsSubsystem
         return mLauncherToggle;
     }
 
+    public double getSlider() {
+        return SmartDashboard.getNumber("Launcher/flywheelRPSSlider", 0);
+    }
+
     /** This method will be called once per scheduler run. */
     @Override
     public void periodic() {


### PR DESCRIPTION
So basically, on Saturday on Jack/Zephyr's request:
- I added a delay of .5 seconds between when the intake is pulled in from a button press and when the motors are turned off in it.
- I added a button to run both conveyors while held.

On Sunday:
- I added a command (unused currently) that will set the launcher to the value on the slider. To test code we probably will add a button to find some values for shooting from various distances, or maybe just have the drive team set it slightly higher for different autonomous starting positions or something.
- I removed the climber lower limit.
- I switched the climber's gear ratio from 12 to 36 for the limiting -- the robot was switched to this to try to fix it. Have not run it.
- There was a *bizarre* glitch with the flight stick's input randomly getting rotated?? wasted some time messing with the IMU when we should have deployed the new code for climber -- IMU is necessary for AbstractDrive but is not used **anywhere** for setting driving currently. Happened like three times.
- Climber limits probably did more harm than good tbh. In the game where we tied we did not have the new code but assuming the climber was not broken before the game (probably was but...) if we did not have the limits we could have raised it high enough. Lower limit was removed so it can be retracted, it will move slow enough now not having an upper one is pretty safe to remove it in case the limits could cause problems again.