### PR TITLE
Added attempt at joystick fix, updated climber, eliminated the IMU

### DIFF
--- a/src/main/java/com/spartronics4915/frc2022/Constants.java
+++ b/src/main/java/com/spartronics4915/frc2022/Constants.java
@@ -182,6 +182,8 @@ public final class Constants
         public static final int kJoystickPort = 0;
         
         public static final int kSlowModeButton = 1;
+        
+        public static final int kFlipJoystickButton = 6;
 
         public static final int kIntakeToggleButton = 2;
 

--- a/src/main/java/com/spartronics4915/frc2022/commands/DriveCommands.java
+++ b/src/main/java/com/spartronics4915/frc2022/commands/DriveCommands.java
@@ -22,6 +22,7 @@ public class DriveCommands
     private boolean mInvertJoystickY;
     private boolean mSlowMode;
     private final Joystick mArcadeController;
+    private boolean mJoystickFlipped = false;
 
     public DriveCommands(Drive drive, Joystick joystick, Joystick arcadeController)
     {
@@ -53,6 +54,15 @@ public class DriveCommands
             // get -1 to 1 values for X and Y of the joystick
             double x = mJoystick.getX();
             double y = mJoystick.getY();
+
+            if(mJoystick.getRawButtonReleased(OIConstants.kFlipJoystickButton)) {
+                mJoystickFlipped = !mJoystickFlipped;
+            }
+
+            if(mJoystickFlipped) {
+                x = -mJoystick.getY();
+                y = -mJoystick.getX();
+            }
             Logger.info(x + ", " + y);
 
             //putting joystick x/y in smartdashboard

--- a/src/main/java/com/spartronics4915/frc2022/commands/DriveCommands.java
+++ b/src/main/java/com/spartronics4915/frc2022/commands/DriveCommands.java
@@ -58,6 +58,14 @@ public class DriveCommands
 
             if(mJoystick.getRawButtonReleased(OIConstants.kFlipJoystickButton)) {
                 mJoystickFlipped = !mJoystickFlipped;
+
+                //TODO: log joystick to console -- move to subsystem??
+                //if(mJoystickFlipped) {
+                //    log in right way("Corrected joystick!");
+                //}
+                //if(!mJoystickFlipped) {
+                //    log in right way("Reset joystick!");
+                //}
             }
 
             if(mJoystickFlipped) {

--- a/src/main/java/com/spartronics4915/frc2022/commands/DriveCommands.java
+++ b/src/main/java/com/spartronics4915/frc2022/commands/DriveCommands.java
@@ -69,8 +69,8 @@ public class DriveCommands
             }
 
             if(mJoystickFlipped) {
-                x = -mJoystick.getY();
-                y = -mJoystick.getX();
+                x = mJoystick.getY();
+                y = mJoystick.getX();
             }
             Logger.info(x + ", " + y + "(ADJUSTED)");
 

--- a/src/main/java/com/spartronics4915/frc2022/commands/DriveCommands.java
+++ b/src/main/java/com/spartronics4915/frc2022/commands/DriveCommands.java
@@ -54,6 +54,7 @@ public class DriveCommands
             // get -1 to 1 values for X and Y of the joystick
             double x = mJoystick.getX();
             double y = mJoystick.getY();
+            Logger.info(x + ", " + y + "(RAW)");
 
             if(mJoystick.getRawButtonReleased(OIConstants.kFlipJoystickButton)) {
                 mJoystickFlipped = !mJoystickFlipped;
@@ -63,7 +64,7 @@ public class DriveCommands
                 x = -mJoystick.getY();
                 y = -mJoystick.getX();
             }
-            Logger.info(x + ", " + y);
+            Logger.info(x + ", " + y + "(ADJUSTED)");
 
             //putting joystick x/y in smartdashboard
             SmartDashboard.putNumber("Drive/Joystick X", mJoystick.getX());

--- a/src/main/java/com/spartronics4915/frc2022/commands/DriveCommands.java
+++ b/src/main/java/com/spartronics4915/frc2022/commands/DriveCommands.java
@@ -75,8 +75,8 @@ public class DriveCommands
             Logger.info(x + ", " + y + "(ADJUSTED)");
 
             //putting joystick x/y in smartdashboard
-            SmartDashboard.putNumber("Drive/Joystick X", mJoystick.getX());
-            SmartDashboard.putNumber("Drive/Joystick Y", mJoystick.getY());
+            SmartDashboard.putNumber("Drive/Joystick X adjusted", mJoystick.getX());
+            SmartDashboard.putNumber("Drive/Joystick Y adjusted", mJoystick.getY());
 
             if (mInvertJoystickY) y = -y;
 

--- a/src/main/java/com/spartronics4915/frc2022/commands/DriveCommands.java
+++ b/src/main/java/com/spartronics4915/frc2022/commands/DriveCommands.java
@@ -55,6 +55,10 @@ public class DriveCommands
             double y = mJoystick.getY();
             Logger.info(x + ", " + y);
 
+            //putting joystick x/y in smartdashboard
+            SmartDashboard.putNumber("Drive/Joystick X", mJoystick.getX());
+            SmartDashboard.putNumber("Drive/Joystick Y", mJoystick.getY());
+
             if (mInvertJoystickY) y = -y;
 
             y = Math.signum(y) * Math.pow(Math.abs(y), kLinearResponseCurveExponent); // apply response curve

--- a/src/main/java/com/spartronics4915/frc2022/subsystems/Climber.java
+++ b/src/main/java/com/spartronics4915/frc2022/subsystems/Climber.java
@@ -24,7 +24,7 @@ public class Climber extends SpartronicsSubsystem
     private TalonFX mMotor1;
     //private TalonFX mMotor2;
     
-    private Solenoid mSolenoid;
+    //private Solenoid mSolenoid;
 
     private double mMotorSpeed;
 
@@ -46,7 +46,7 @@ public class Climber extends SpartronicsSubsystem
 
             //mMotorSensors = new TalonFXSensorCollection()
 
-            mSolenoid = new Solenoid(Constants.kPCMId, PneumaticsModuleType.CTREPCM, kClimberSolenoidId);
+            //mSolenoid = new Solenoid(Constants.kPCMId, PneumaticsModuleType.CTREPCM, kClimberSolenoidId);
         }
         catch (Exception exception)
         {
@@ -73,7 +73,7 @@ public class Climber extends SpartronicsSubsystem
         // logInfo("Set Solenoid to " + isExtended);
         if (mIsInitialized)
         {
-            mSolenoid.set(isExtended != kSolenoidIsInverted);
+           // mSolenoid.set(isExtended != kSolenoidIsInverted);
         }
     }
 

--- a/src/main/java/com/spartronics4915/frc2022/subsystems/Drive.java
+++ b/src/main/java/com/spartronics4915/frc2022/subsystems/Drive.java
@@ -23,8 +23,8 @@ public class Drive extends AbstractDrive
                 kRightMotorID,
                 SensorModel.fromWheelDiameter(kWheelDiameter, kNativeUnitsPerRevolution),
                 kRightFollowerMotorID
-            ),
-            new SpartronicsPigeon(kPigeonID)
+            )/*,
+            new SpartronicsPigeon(kPigeonID)*/
         );
 
         // output inversion

--- a/src/main/java/com/spartronics4915/lib/subsystems/drive/AbstractDrive.java
+++ b/src/main/java/com/spartronics4915/lib/subsystems/drive/AbstractDrive.java
@@ -9,29 +9,29 @@ import com.spartronics4915.lib.subsystems.SpartronicsSubsystem;
 public abstract class AbstractDrive extends SpartronicsSubsystem
 {
     protected final SpartronicsMotor mLeftMotor, mRightMotor;
-    protected final SpartronicsIMU mIMU;
+    //protected final SpartronicsIMU mIMU;
 
-    protected Rotation2d mIMUOffset = new Rotation2d();
+    //protected Rotation2d mIMUOffset = new Rotation2d();
 
     /**
      * This constructor will set up everything you need. It's protected to allow for
      * a singleton drivetrain.
      */
-    protected AbstractDrive(SpartronicsMotor leftMotor, SpartronicsMotor rightMotor,
-        SpartronicsIMU imu)
+    protected AbstractDrive(SpartronicsMotor leftMotor, SpartronicsMotor rightMotor/*,
+        SpartronicsIMU imu*/)
     {
         if (leftMotor.hadStartupError() || rightMotor.hadStartupError())
         {
             mLeftMotor = new SpartronicsSimulatedMotor(leftMotor.getDeviceNumber(), leftMotor.getFollower().getDeviceNumber());
             mRightMotor = new SpartronicsSimulatedMotor(rightMotor.getDeviceNumber(), rightMotor.getFollower().getDeviceNumber());
-            mIMU = new SpartronicsIMU()
-            {
+            //mIMU = new SpartronicsIMU()
+            /*{
                 @Override
                 public Rotation2d getYaw()
                 {
                     return new Rotation2d();
                 }
-            };
+            };*/
 
             logInitialized(false);
         }
@@ -39,7 +39,7 @@ public abstract class AbstractDrive extends SpartronicsSubsystem
         {
             mLeftMotor = leftMotor;
             mRightMotor = rightMotor;
-            mIMU = imu;
+            //mIMU = imu;
 
             logInitialized(true);
         }
@@ -52,10 +52,10 @@ public abstract class AbstractDrive extends SpartronicsSubsystem
      *
      * @param heading Heading to set the IMU to.
      */
-    public void setIMUHeading(Rotation2d heading)
+    /*public void setIMUHeading(Rotation2d heading)
     {
         mIMUOffset = mIMU.getYaw().minus(heading);
-    }
+    }*/
 
     /**
      * This gets the heading of the IMU, but this should almost exclusively be
@@ -64,10 +64,10 @@ public abstract class AbstractDrive extends SpartronicsSubsystem
      *
      * @return Heading of the IMU.
      */
-    public Rotation2d getIMUHeading()
+    /*public Rotation2d getIMUHeading()
     {
         return mIMU.getYaw().rotateBy(mIMUOffset);
-    }
+    }*/
 
     public double getTurretAngle()
     {
@@ -136,8 +136,8 @@ public abstract class AbstractDrive extends SpartronicsSubsystem
     @Override
     public void periodic()
     {
-        dashboardPutNumber("imuHeading", mIMU.getYaw().getDegrees());
-        dashboardPutNumber("imuHeadingAdjusted", getIMUHeading().getDegrees());
+        //dashboardPutNumber("imuHeading", mIMU.getYaw().getDegrees());
+        //dashboardPutNumber("imuHeadingAdjusted", getIMUHeading().getDegrees());
 
         dashboardPutNumber("leftSpeed", getLeftMotor().getEncoder().getVelocity());
         dashboardPutNumber("rightSpeed", getRightMotor().getEncoder().getVelocity());

--- a/src/main/java/com/spartronics4915/lib/subsystems/drive/CharacterizeDriveBaseCommand.java
+++ b/src/main/java/com/spartronics4915/lib/subsystems/drive/CharacterizeDriveBaseCommand.java
@@ -84,7 +84,8 @@ public class CharacterizeDriveBaseCommand implements Command
         mOutputArray[6] = rightPosition;
         mOutputArray[7] = leftVelocity;
         mOutputArray[8] = rightVelocity;
-        mOutputArray[9] = mDrive.getIMUHeading().getRadians();
+        mOutputArray[9] = 2;//mDrive.getIMUHeading().getRadians();
+
 
         mTelemetryEntry.setNumberArray(mOutputArray);
     }

--- a/src/main/java/com/spartronics4915/lib/subsystems/estimator/RobotStateEstimator.java
+++ b/src/main/java/com/spartronics4915/lib/subsystems/estimator/RobotStateEstimator.java
@@ -149,7 +149,7 @@ public class RobotStateEstimator extends SpartronicsSubsystem
         {
             mSLAMCamera.setPose(pose);
         }
-        mDrive.setIMUHeading(pose.getRotation());
+        //mDrive.setIMUHeading(pose.getRotation());
     }
 
     @Override
@@ -214,18 +214,18 @@ public class RobotStateEstimator extends SpartronicsSubsystem
             final double rightDist = mDrive.getRightMotor().getEncoder().getPosition();
             final double leftDelta = leftDist - mLeftPrevDist;
             final double rightDelta = rightDist - mRightPrevDist;
-            final Rotation2d heading = mDrive.getIMUHeading();
+            //final Rotation2d heading = mDrive.getIMUHeading();
             mLeftPrevDist = leftDist;
             mRightPrevDist = rightDist;
-            iVal = mKinematics.forwardKinematics(last.pose.getRotation(), leftDelta, rightDelta,
-                heading);
+            //iVal = mKinematics.forwardKinematics(last.pose.getRotation(), leftDelta, rightDelta,
+                //heading);
             
             if (mBestEstimatorSource == EstimatorSource.Fused)
             {
-                var ekfPose = mEKF.update(mCameraStateMap.getLatestFieldToVehicle(), leftDist, rightDist, heading.getRadians() - mPrevHeading, ts);
+                //var ekfPose = mEKF.update(mCameraStateMap.getLatestFieldToVehicle(), leftDist, rightDist, heading.getRadians() - mPrevHeading, ts);
                 
-                mPrevHeading = heading.getRadians();
-                mFusedStateMap.addObservations(ts, ekfPose);
+                //mPrevHeading = heading.getRadians();
+                //mFusedStateMap.addObservations(ts, ekfPose);
             }
         }
 
@@ -233,22 +233,22 @@ public class RobotStateEstimator extends SpartronicsSubsystem
          * integrateForward: given a last state and a current velocity,
          * estimate a new state (P2 = P1 + dPdt * dt)
          */
-        Pose2d nextP = mKinematics.integrateForwardKinematics(last.pose, iVal);
+        //Pose2d nextP = mKinematics.integrateForwardKinematics(last.pose, iVal);
 
         /* record the new state estimate */
-        mEncoderStateMap.addObservations(ts, nextP);
+        //mEncoderStateMap.addObservations(ts, nextP);
 
         if (mBestEstimatorSource == EstimatorSource.VisionResetEncoderOdometry)
         {
-            nextP = mKinematics.integrateForwardKinematics(
-                mVisionResetEncoderStateMap.getLatestFieldToVehicle(), iVal);
-            mVisionResetEncoderStateMap.addObservations(ts, nextP);
+            //nextP = mKinematics.integrateForwardKinematics(
+                //mVisionResetEncoderStateMap.getLatestFieldToVehicle(), iVal);
+            //mVisionResetEncoderStateMap.addObservations(ts, nextP);
         }
 
         // We convert meters/loopinterval and radians/loopinterval to meters/sec and
         // radians/sec
         final double loopintervalToSeconds = 1 / (ts - last.timestamp);
-        final Twist2d normalizedIVal = new Twist2d(iVal.dx * loopintervalToSeconds, iVal.dy * loopintervalToSeconds, iVal.dtheta * loopintervalToSeconds);
+        //final Twist2d normalizedIVal = new Twist2d(iVal.dx * loopintervalToSeconds, iVal.dy * loopintervalToSeconds, iVal.dtheta * loopintervalToSeconds);
 
         if (mSLAMCamera != null)
         {
@@ -257,7 +257,7 @@ public class RobotStateEstimator extends SpartronicsSubsystem
                 // Sometimes (for unknown reasons) the native code can't send odometry info.
                 // We throw a Java exception when this happens, but we'd like to ignore that
                 // exception in this situation.
-                mSLAMCamera.sendOdometry(normalizedIVal);
+                //mSLAMCamera.sendOdometry(normalizedIVal);
             }
             catch (CameraJNIException e)
             {


### PR DESCRIPTION
Joystick axes are swapped when button 6 toggles on a boolean. Mitchell says the directions are still wrong -- probably need to reverse the values too?

Switched the climber to not use the solenoid because it was removed along with the ratchet -- this ended up not working at all physically.

They swapped the IMU and it did not fix the joystick at all, so I removed every reference to the IMU to see if like there's any possible thing it was doing -- have not tested crashing (doubt it changes anything w/o IMU) but IMU is not necessary for code and is not accidentally used anywhere clearly now.