### PR TITLE
Use slider with ShootFar [for testing]; add getAmps for possible addition to climber code

### DIFF
--- a/src/main/java/com/spartronics4915/frc2022/commands/LauncherCommands.java
+++ b/src/main/java/com/spartronics4915/frc2022/commands/LauncherCommands.java
@@ -115,7 +115,7 @@ public class LauncherCommands {
         // Called when the command is initially scheduled.
         @Override
         public void initialize() {
-            mLauncher.setMotorSpeed(Flywheel.kFarRPS);
+            mLauncher.setMotorSpeed(mLauncher.getSlider());
             mLauncher.setToggleTrue();
         }
 

--- a/src/main/java/com/spartronics4915/frc2022/subsystems/Climber.java
+++ b/src/main/java/com/spartronics4915/frc2022/subsystems/Climber.java
@@ -86,7 +86,7 @@ public class Climber extends SpartronicsSubsystem
     }
 
     public double getAmps(TalonFX motor) {
-        return motor.getSensorCollection().getStatorCurrent();
+        return motor.getStatorCurrent();
     }
 
     /** This method will be called once per scheduler run. */

--- a/src/main/java/com/spartronics4915/frc2022/subsystems/Climber.java
+++ b/src/main/java/com/spartronics4915/frc2022/subsystems/Climber.java
@@ -85,6 +85,10 @@ public class Climber extends SpartronicsSubsystem
         return 0.0;
     }
 
+    public double getAmps(TalonFX motor) {
+        return motor.getSensorCollection().getStatorCurrent();
+    }
+
     /** This method will be called once per scheduler run. */
     @Override
     public void periodic() {


### PR DESCRIPTION
Made the ShootFar command use the slider -- want to find a good value.

Chris wants to maybe read climber voltage to see when it is about to leave the ground and slow it down for a bit -- he thinks swinging might be possible to decrease, and that that would put less strain on the gears.